### PR TITLE
bridge display names (also port to newer discord.py)

### DIFF
--- a/src/achievement.py
+++ b/src/achievement.py
@@ -47,7 +47,7 @@ async def achieve(bot: commands.Bot, message: discord.Message, achievement):
     await bot.database.commit()
     logging.info("Awarded achievement %s to %s", achievement, message.author.name)
 
-def setup(bot):
+async def setup(bot):
     @bot.group(name="achievements", aliases=["ach", "achieve", "achievement"], brief="Achieve a wide variety of fun achievements!", help=f"""
     Do things and get arbitrary achievements for them!
     Note that due to reasons messages for achievements will not be shown except in opted-in servers, although achievements will be gained regardless.

--- a/src/commands.py
+++ b/src/commands.py
@@ -177,5 +177,5 @@ AutoBotRobot is operated by gollark/osmarks.
 
         await ctx.send("\n".join(map(lambda x: f"{x[0]} x{x[1]}", results)))
 
-def setup(bot):
-    bot.add_cog(GeneralCommands(bot))
+async def setup(bot):
+    await bot.add_cog(GeneralCommands(bot))

--- a/src/debug.py
+++ b/src/debug.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 import util
 import eventbus
 
-def setup(bot):
+async def setup(bot):
     @bot.group(help="Debug/random messing around utilities. Owner-only.")
     @commands.check(util.admin_check)
     async def magic(ctx):
@@ -76,6 +76,6 @@ def setup(bot):
     @magic.command(help="Reload extensions (all or the specified one).")
     async def reload_ext(ctx, ext="all"):
         if ext == "all":
-            for ext in util.extensions: bot.reload_extension(ext)
-        else: bot.reload_extension(ext)
+            for ext in util.extensions: await bot.reload_extension(ext)
+        else: await bot.reload_extension(ext)
         await ctx.send("Done!")

--- a/src/esoserver.py
+++ b/src/esoserver.py
@@ -8,7 +8,7 @@ import metrics
 
 role_transfer_lock = asyncio.Lock()
 
-def setup(bot):
+async def setup(bot):
 	@bot.listen()
 	async def on_message(message):
 		if message.guild and message.guild.id == util.config["esoserver"]["id"]:

--- a/src/heavserver.py
+++ b/src/heavserver.py
@@ -5,7 +5,7 @@ import discord
 
 import metrics
 
-def setup(bot):
+async def setup(bot):
 	@bot.listen()
 	async def on_member_join(member):
 		if member.guild and member.guild.id == util.config["heavserver"]["id"]:

--- a/src/irc_link.py
+++ b/src/irc_link.py
@@ -89,7 +89,7 @@ async def initialize():
             for line in lines:
                 conn.privmsg(channel_name, render_line(msg.author, line))
             for at in msg.attachments:
-                conn.privmsg(channel_name, render_line(msg.author, f"-> {at.filename}: {at.proxy_url}"))
+                conn.privmsg(channel_name, render_line(msg.author, f"-> {at.filename}: {at.url}"))
         else:
             logging.warning("IRC channel %s not allowed", channel_name)
 
@@ -113,7 +113,7 @@ async def initialize():
     global unlisten
     unlisten = eventbus.add_listener(util.config["irc"]["name"], on_bridge_message)
 
-def setup(bot):
+async def setup(bot):
     asyncio.create_task(initialize())
 
 def teardown(bot=None):

--- a/src/main.py
+++ b/src/main.py
@@ -27,6 +27,7 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s %(asctime)s %(mess
 
 intents = discord.Intents.default()
 intents.members = True
+intents.message_content = True
 
 bot = commands.Bot(command_prefix=commands.when_mentioned_or(config["prefix"]), description="AutoBotRobot, the most useless bot in the known universe." + util.config.get("description_suffix", ""), 
     case_insensitive=True, allowed_mentions=discord.AllowedMentions(everyone=False, users=True, roles=True), intents=intents)
@@ -103,10 +104,11 @@ guild_count.set_function(get_guild_count)
 async def run_bot():
     bot.database = await db.init(config["database"])
     await eventbus.initial_load(bot.database)
-    for ext in util.extensions:
-        logging.info("Loaded %s", ext)
-        bot.load_extension(ext)
-    await bot.start(config["token"])
+    async with bot:
+        for ext in util.extensions:
+            logging.info("Loaded %s", ext)
+            await bot.load_extension(ext)
+        await bot.start(config["token"])
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()

--- a/src/reminders.py
+++ b/src/reminders.py
@@ -178,10 +178,10 @@ class Reminders(commands.Cog):
                     self.reminder_queue.pop(0)
                     await self.fire_reminder(next_id)
 
-def setup(bot):
+async def setup(bot):
     cog = Reminders(bot)
     asyncio.create_task(cog.init_reminders())
-    bot.add_cog(cog)
+    await bot.add_cog(cog)
 
 def teardown(bot):
     bot.rloop_task.cancel()

--- a/src/search.py
+++ b/src/search.py
@@ -94,6 +94,6 @@ class Search(commands.Cog):
         if self.pool is not None:
             self.pool.shutdown()
 
-def setup(bot):
+async def setup(bot):
     cog = Search(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/src/telephone.py
+++ b/src/telephone.py
@@ -93,7 +93,7 @@ class Telephone(commands.Cog):
         channel = self.bot.get_channel(channel_id)
         if channel:
             webhook = self.webhooks.get(channel_id)
-            attachments_text = "\n".join(f"{at.filename}: {at.proxy_url}" for at in msg.attachments)
+            attachments_text = "\n".join(f"{at.filename}: {at.url}" for at in msg.attachments)
             async def send_raw(text):
                 if webhook:
                     try:
@@ -132,7 +132,7 @@ class Telephone(commands.Cog):
                 reply = (eventbus.AuthorInfo(replying_to.author.name, replying_to.author.id, str(replying_to.author.display_avatar.url), replying_to.author.bot), parse_formatting(self.bot, replying_to.content))
             else:
                 reply = (None, None)
-        msg = eventbus.Message(eventbus.AuthorInfo(msg.author.name, msg.author.id, str(msg.author.display_avatar.url), msg.author.bot), 
+        msg = eventbus.Message(eventbus.AuthorInfo(msg.author.global_name or msg.author.name, msg.author.id, str(msg.author.display_avatar.url), msg.author.bot), 
             parse_formatting(self.bot, msg.content), ("discord", channel_id), msg.id, [ at for at in msg.attachments if not at.is_spoiler() ], reply=reply)
         await eventbus.push(msg)
 
@@ -424,7 +424,7 @@ When you want to end a call, use hangup.
         finally:
             os.unlink(tmppath)
 
-def setup(bot):
+async def setup(bot):
     cog = Telephone(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)
     asyncio.create_task(cog.initial_load_webhooks())

--- a/src/userdata.py
+++ b/src/userdata.py
@@ -87,5 +87,5 @@ class Userdata(commands.Cog):
             await self.bot.database.commit()
             await ctx.send(f"**{key}** deleted")
 
-def setup(bot):
-    bot.add_cog(Userdata(bot))
+async def setup(bot):
+    await bot.add_cog(Userdata(bot))

--- a/src/util.py
+++ b/src/util.py
@@ -267,7 +267,7 @@ async def get_asset(bot: commands.Bot, identifier):
         return x["url"]
     file = discord.File(os.path.join("./assets", identifier), filename=safe_ident)
     message = await (bot.get_channel(config["image_upload_channel"])).send(identifier, file=file)
-    url = message.attachments[0].proxy_url
+    url = message.attachments[0].url
     await bot.database.execute("INSERT INTO assets VALUES (?, ?)", (safe_ident, url))
     return url
 

--- a/src/voice.py
+++ b/src/voice.py
@@ -16,7 +16,7 @@ class HTTPSource(discord.AudioSource):
     def read(self): return next(self.packets, b"")
     def is_opus(self): return True
 
-def setup(bot):
+async def setup(bot):
     # experimental, thus limit to me only
     @bot.group()
     @commands.check(util.admin_check)


### PR DESCRIPTION
this changes messages bridged from discord to use the new display names instead of usernames (because of the username change all of those will become lowercase).

`global_name` is only available in discord.py 2.3. this doesn't actually change that much, mostly using more asyncs and awaits around coroutines. the older versions use a deprecated api version so it's probably a good idea to port anyways

i havent tested everything, some things might have broken. i know bridging and extension reloading works though